### PR TITLE
Make model attributes optional

### DIFF
--- a/src/myPyllant/models.py
+++ b/src/myPyllant/models.py
@@ -76,9 +76,9 @@ class Circuit(BaseModel):
     index: int
     circuit_state: str
     current_circuit_flow_temperature: float
-    heating_curve: float
+    heating_curve: float | None
     is_cooling_allowed: bool
-    min_flow_temperature_setpoint: float
+    min_flow_temperature_setpoint: float | None
     mixer_circuit_type_external: str
     set_back_mode_enabled: bool
     zones: list = []

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -36,7 +36,7 @@ async def test_systems() -> None:
         assert isinstance(system, System), "Expected System return type"
         assert isinstance(system.status_online, bool)
         assert isinstance(system.status_error, bool)
-        assert isinstance(system.outdoor_temperature, float)
+        assert isinstance(system.outdoor_temperature, (float | None))
         assert isinstance(system.mode, str)
         assert isinstance(system.water_pressure, float)
         await api.aiohttp_session.close()


### PR DESCRIPTION
## What?
- Make `heating_curve` and `min_flow_temperature_setpoint` of `Circuit` optional. 
- Make `outdoor_temperature` assert check for None.

## Why?
Test failing;
```python3
src/myPyllant/export.py:45: in main
    async for system in api.get_systems():
src/myPyllant/api.py:198: in get_systems
    system = System(
src/myPyllant/models.py:115: in __init__
    self.circuits = [Circuit(system_id=self.id, **c) for c in self._raw_circuits]
src/myPyllant/models.py:115: in <listcomp>
    self.circuits = [Circuit(system_id=self.id, **c) for c in self._raw_circuits]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   pydantic.error_wrappers.ValidationError: 2 validation errors for Circuit
E   heating_curve
E     field required (type=value_error.missing)
E   min_flow_temperature_setpoint
E     field required (type=value_error.missing)
```

In my case, `outdoor_temperature` does not exist either.
```python3
ERROR    myPyllant.models:models.py:156 Could not get outdoor temperature from system control state
Traceback (most recent call last):
  File "/Users/-/GitHub/myPyllant/src/myPyllant/models.py", line 152, in outdoor_temperature
    return self.system_control_state["control_state"]["general"][
KeyError: 'outdoor_temperature'
```

## How will I know if this breaks?
--
