### PR TITLE
Anonymize generated test data

### DIFF
--- a/tests/generate_test_data.py
+++ b/tests/generate_test_data.py
@@ -4,6 +4,7 @@ import argparse
 import asyncio
 import copy
 from datetime import datetime, timedelta
+import hashlib
 import json
 from pathlib import Path
 import sys
@@ -93,7 +94,7 @@ def _recursive_data_anonymize(data: str | dict | list) -> dict:
     elif isinstance(data, dict):
         for elem in data.keys():
             if elem in ANONYMIZE_ATTRIBUTES:
-                data[elem] = "ANONYMIZED"
+                data[elem] = hashlib.sha1(data[elem].encode("UTF-8")).hexdigest()
                 continue
             _recursive_data_anonymize(data[elem])
 

--- a/tests/generate_test_data.py
+++ b/tests/generate_test_data.py
@@ -2,10 +2,11 @@
 
 import argparse
 import asyncio
-from datetime import datetime, timedelta
+import copy
 import json
-from pathlib import Path
 import sys
+from datetime import datetime, timedelta
+from pathlib import Path
 from urllib.parse import urlencode
 
 sys.path.append((Path(__file__).resolve().parent / "src").name)
@@ -18,7 +19,7 @@ parser.add_argument("password", help="Password for the myVaillant app")
 
 
 JSON_DIR = Path(__file__).resolve().parent / "json"
-
+ANONYMIZE_ATTRIBUTES = ("device_uuid", "device_serial_number", "deviceId", "serialNumber", "systemId")
 
 async def main(user, password):
     """
@@ -39,7 +40,8 @@ async def main(user, password):
         ) as systems_resp:
             system = await systems_resp.json()
             with open(JSON_DIR / "systems.json", "w") as fh:
-                fh.write(json.dumps(await systems_resp.json(), indent=2))
+                anonymized_system = _recursive_data_anonymize(copy.deepcopy(system))
+                fh.write(json.dumps(anonymized_system, indent=2))
 
         system_url = f"{API_URL_BASE}/emf/v2/{system[0]['systemId']}/currentSystem"
         async with api.aiohttp_session.get(
@@ -47,7 +49,8 @@ async def main(user, password):
         ) as current_system_resp:
             with open(JSON_DIR / "current_system.json", "w") as fh:
                 current_system = await current_system_resp.json()
-                fh.write(json.dumps(current_system, indent=2))
+                anonymized_current_system = _recursive_data_anonymize(copy.deepcopy(current_system))
+                fh.write(json.dumps(anonymized_current_system, indent=2))
 
         device = current_system["primary_heat_generator"]
         start = datetime.now().replace(
@@ -71,6 +74,22 @@ async def main(user, password):
             with open(JSON_DIR / "device_buckets.json", "w") as fh:
                 device_buckets = await device_buckets_resp.json()
                 fh.write(json.dumps(device_buckets, indent=2))
+
+
+def _recursive_data_anonymize(data: str | dict | list) -> dict:
+
+    if isinstance(data, list):
+        for elem in data:
+            _recursive_data_anonymize(elem)
+
+    elif isinstance(data, dict):
+        for elem in data.keys():
+            if elem in ANONYMIZE_ATTRIBUTES:
+                data[elem] = "ANONYMIZED"
+                continue
+            _recursive_data_anonymize(data[elem])
+
+    return data
 
 
 if __name__ == "__main__":

--- a/tests/generate_test_data.py
+++ b/tests/generate_test_data.py
@@ -3,10 +3,10 @@
 import argparse
 import asyncio
 import copy
-import json
-import sys
 from datetime import datetime, timedelta
+import json
 from pathlib import Path
+import sys
 from urllib.parse import urlencode
 
 sys.path.append((Path(__file__).resolve().parent / "src").name)
@@ -19,7 +19,14 @@ parser.add_argument("password", help="Password for the myVaillant app")
 
 
 JSON_DIR = Path(__file__).resolve().parent / "json"
-ANONYMIZE_ATTRIBUTES = ("device_uuid", "device_serial_number", "deviceId", "serialNumber", "systemId")
+ANONYMIZE_ATTRIBUTES = (
+    "device_uuid",
+    "device_serial_number",
+    "deviceId",
+    "serialNumber",
+    "systemId",
+)
+
 
 async def main(user, password):
     """
@@ -49,7 +56,9 @@ async def main(user, password):
         ) as current_system_resp:
             with open(JSON_DIR / "current_system.json", "w") as fh:
                 current_system = await current_system_resp.json()
-                anonymized_current_system = _recursive_data_anonymize(copy.deepcopy(current_system))
+                anonymized_current_system = _recursive_data_anonymize(
+                    copy.deepcopy(current_system)
+                )
                 fh.write(json.dumps(anonymized_current_system, indent=2))
 
         device = current_system["primary_heat_generator"]
@@ -77,7 +86,6 @@ async def main(user, password):
 
 
 def _recursive_data_anonymize(data: str | dict | list) -> dict:
-
     if isinstance(data, list):
         for elem in data:
             _recursive_data_anonymize(elem)

--- a/tests/test_generate_test_data.py
+++ b/tests/test_generate_test_data.py
@@ -45,29 +45,29 @@ def test_anonymize_systems_data():
     assert anonymized_data == [
         {
             "gateway": {
-                "deviceId": "ANONYMIZED",
-                "serialNumber": "ANONYMIZED",
-                "systemId": "ANONYMIZED",
+                "deviceId": "707e295cf73b49584939e3fe6e0a96713ca22800",
+                "serialNumber": "f18bbf5a183946e978558a1556ed62c4cfb9dc5e",
+                "systemId": "823c180c5c91bff1ab96e14d253aaa8218b511f4",
                 "diagnosticTroubleCodes": [],
             },
             "devices": [
                 {
-                    "deviceId": "ANONYMIZED",
-                    "serialNumber": "ANONYMIZED",
+                    "deviceId": "707e295cf73b49584939e3fe6e0a96713ca22800",
+                    "serialNumber": "f18bbf5a183946e978558a1556ed62c4cfb9dc5e",
                     "articleNumber": "0020260951",
                     "name": "sensoHOME",
                     "type": "CONTROL",
-                    "systemId": "ANONYMIZED",
+                    "systemId": "823c180c5c91bff1ab96e14d253aaa8218b511f4",
                     "diagnosticTroubleCodes": [],
                 },
                 {
-                    "deviceId": "ANONYMIZED",
-                    "serialNumber": "ANONYMIZED",
+                    "deviceId": "707e295cf73b49584939e3fe6e0a96713ca22800",
+                    "serialNumber": "f18bbf5a183946e978558a1556ed62c4cfb9dc5e",
                     "articleNumber": "0010022040",
                     "name": "ecoTEC",
                     "type": "HEAT_GENERATOR",
                     "operationalData": {},
-                    "systemId": "ANONYMIZED",
+                    "systemId": "823c180c5c91bff1ab96e14d253aaa8218b511f4",
                     "diagnosticTroubleCodes": [],
                     "properties": [],
                 },
@@ -75,7 +75,7 @@ def test_anonymize_systems_data():
             "status": {},
             "systemControlState": {},
             "systemConfiguration": {},
-            "systemId": "ANONYMIZED",
+            "systemId": "823c180c5c91bff1ab96e14d253aaa8218b511f4",
             "hasOwnership": True,
         }
     ]
@@ -109,13 +109,13 @@ def test_anonymize_current_system():
     assert anonymized_data == {
         "system_type": "BOILER_OR_ELECTRIC_HEATER",
         "primary_heat_generator": {
-            "device_uuid": "ANONYMIZED",
+            "device_uuid": "53be2a18985b87f5613e32a9ba44cc4ccbb4f6b4",
             "ebus_id": "BAI00",
             "spn": 376,
             "bus_coupler_address": 0,
             "article_number": "0010022040",
             "emfValid": True,
-            "device_serial_number": "ANONYMIZED",
+            "device_serial_number": "d97b53961ee397e2e9b1bb0cabff02949c360f4f",
             "device_type": "BOILER",
             "first_data": "2022-11-10T13:33:34Z",
             "last_data": "2023-02-28T13:20:31Z",

--- a/tests/test_generate_test_data.py
+++ b/tests/test_generate_test_data.py
@@ -127,4 +127,3 @@ def test_anonymize_current_system():
         "solar_station": None,
         "ventilation": None,
     }
-

--- a/tests/test_generate_test_data.py
+++ b/tests/test_generate_test_data.py
@@ -1,0 +1,130 @@
+from tests.generate_test_data import _recursive_data_anonymize
+
+
+def test_anonymize_systems_data():
+    original_systems_data = [
+        {
+            "gateway": {
+                "deviceId": "PRIVATE_deviceId",
+                "serialNumber": "PRIVATE_serialNumber",
+                "systemId": "PRIVATE_systemId",
+                "diagnosticTroubleCodes": [],
+            },
+            "devices": [
+                {
+                    "deviceId": "PRIVATE_deviceId",
+                    "serialNumber": "PRIVATE_serialNumber",
+                    "articleNumber": "0020260951",
+                    "name": "sensoHOME",
+                    "type": "CONTROL",
+                    "systemId": "PRIVATE_systemId",
+                    "diagnosticTroubleCodes": [],
+                },
+                {
+                    "deviceId": "PRIVATE_deviceId",
+                    "serialNumber": "PRIVATE_serialNumber",
+                    "articleNumber": "0010022040",
+                    "name": "ecoTEC",
+                    "type": "HEAT_GENERATOR",
+                    "operationalData": {},
+                    "systemId": "PRIVATE_systemId",
+                    "diagnosticTroubleCodes": [],
+                    "properties": [],
+                },
+            ],
+            "status": {},
+            "systemControlState": {},
+            "systemConfiguration": {},
+            "systemId": "PRIVATE_systemId",
+            "hasOwnership": True,
+        }
+    ]
+
+    anonymized_data = _recursive_data_anonymize(original_systems_data)
+
+    assert anonymized_data == [
+        {
+            "gateway": {
+                "deviceId": "ANONYMIZED",
+                "serialNumber": "ANONYMIZED",
+                "systemId": "ANONYMIZED",
+                "diagnosticTroubleCodes": [],
+            },
+            "devices": [
+                {
+                    "deviceId": "ANONYMIZED",
+                    "serialNumber": "ANONYMIZED",
+                    "articleNumber": "0020260951",
+                    "name": "sensoHOME",
+                    "type": "CONTROL",
+                    "systemId": "ANONYMIZED",
+                    "diagnosticTroubleCodes": [],
+                },
+                {
+                    "deviceId": "ANONYMIZED",
+                    "serialNumber": "ANONYMIZED",
+                    "articleNumber": "0010022040",
+                    "name": "ecoTEC",
+                    "type": "HEAT_GENERATOR",
+                    "operationalData": {},
+                    "systemId": "ANONYMIZED",
+                    "diagnosticTroubleCodes": [],
+                    "properties": [],
+                },
+            ],
+            "status": {},
+            "systemControlState": {},
+            "systemConfiguration": {},
+            "systemId": "ANONYMIZED",
+            "hasOwnership": True,
+        }
+    ]
+
+
+def test_anonymize_current_system():
+    original_current_system_data = {
+        "system_type": "BOILER_OR_ELECTRIC_HEATER",
+        "primary_heat_generator": {
+            "device_uuid": "private_device_uuid",
+            "ebus_id": "BAI00",
+            "spn": 376,
+            "bus_coupler_address": 0,
+            "article_number": "0010022040",
+            "emfValid": True,
+            "device_serial_number": "private_device_serial_number",
+            "device_type": "BOILER",
+            "first_data": "2022-11-10T13:33:34Z",
+            "last_data": "2023-02-28T13:20:31Z",
+            "data": [],
+            "product_name": "VMW 23CS/1-5 C (N-ES) ecoTEC plus",
+        },
+        "secondary_heat_generators": [],
+        "electric_backup_heater": None,
+        "solar_station": None,
+        "ventilation": None,
+    }
+
+    anonymized_data = _recursive_data_anonymize(original_current_system_data)
+
+    assert anonymized_data == {
+        "system_type": "BOILER_OR_ELECTRIC_HEATER",
+        "primary_heat_generator": {
+            "device_uuid": "ANONYMIZED",
+            "ebus_id": "BAI00",
+            "spn": 376,
+            "bus_coupler_address": 0,
+            "article_number": "0010022040",
+            "emfValid": True,
+            "device_serial_number": "ANONYMIZED",
+            "device_type": "BOILER",
+            "first_data": "2022-11-10T13:33:34Z",
+            "last_data": "2023-02-28T13:20:31Z",
+            "data": [],
+            "product_name": "VMW 23CS/1-5 C (N-ES) ecoTEC plus",
+        },
+        "secondary_heat_generators": [],
+        "electric_backup_heater": None,
+        "solar_station": None,
+        "ventilation": None,
+    }
+


### PR DESCRIPTION
## What
Before persisting sample responses of the API, anonymize the following fields;
```python3
("device_uuid", "device_serial_number", "deviceId", "serialNumber", "systemId")
```
To do this, we recursively traverse the `dict` looking for the fields anywhere inside the response.

## Why
In order to start supporting more devices, we should find a way to store the test data of users in the repo without compromising private info. 
That way, we could test any change against known API responses.

