### PR TITLE
Add python-dateutil as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
 dependencies = [
   "aiohttp>=3.8.0",
   "dacite==1.8.1",
+  "python-dateutil",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
The MyPyllantAPI uses dateutil.tz but dateutil was not installed as a dependency. This line should fix this.