### PR TITLE
ambisense: set operation mode and quick veto

### DIFF
--- a/src/myPyllant/enums.py
+++ b/src/myPyllant/enums.py
@@ -111,3 +111,9 @@ class VentilationOperationMode(MyPyllantEnum):
 class VentilationFanStageType(MyPyllantEnum):
     DAY = "DAY"
     NIGHT = "NIGHT"
+
+
+class AmbisenseRoomOperationMode(MyPyllantEnum):
+    MANUAL = "MANUAL"
+    OFF = "OFF"
+    AUTO = "AUTO"

--- a/src/myPyllant/export.py
+++ b/src/myPyllant/export.py
@@ -61,6 +61,7 @@ async def main(
             include_diagnostic_trouble_codes=True,
             include_rts=True,
             include_mpc=True,
+            include_ambisense_rooms=True,
         ):
             if data:
                 for device in system.devices:
@@ -74,6 +75,16 @@ async def main(
 
             else:
                 export_list.append(system.prepare_dict())
+
+            # TODO to be removed, but to ensure that it works with real API calls
+            # await api.quick_veto_ambisense_room(system.ambisense_rooms[0], 12, 100)
+            # await api.cancel_quick_veto_ambisense_room(system.ambisense_rooms[0])
+            # await api.set_ambisense_room_operation_mode(
+            #    system.ambisense_rooms[0], AmbisenseRoomOperationMode.OFF
+            # )
+            # await api.set_ambisense_room_operation_mode(
+            #    system.ambisense_rooms[0], AmbisenseRoomOperationMode.AUTO
+            # )
 
         return export_list
 

--- a/src/myPyllant/export.py
+++ b/src/myPyllant/export.py
@@ -76,16 +76,6 @@ async def main(
             else:
                 export_list.append(system.prepare_dict())
 
-            # TODO to be removed, but to ensure that it works with real API calls
-            # await api.quick_veto_ambisense_room(system.ambisense_rooms[0], 12, 100)
-            # await api.cancel_quick_veto_ambisense_room(system.ambisense_rooms[0])
-            # await api.set_ambisense_room_operation_mode(
-            #    system.ambisense_rooms[0], AmbisenseRoomOperationMode.OFF
-            # )
-            # await api.set_ambisense_room_operation_mode(
-            #    system.ambisense_rooms[0], AmbisenseRoomOperationMode.AUTO
-            # )
-
         return export_list
 
 

--- a/src/myPyllant/models.py
+++ b/src/myPyllant/models.py
@@ -692,6 +692,7 @@ class AmbisenseDevice(MyPyllantDataClass):
     low_bat: bool
     name: str
     rssi: int
+    rssi_peer: int
     sgtin: str
     unreach: bool
 
@@ -711,7 +712,6 @@ class AmbisenseRoomConfiguration(MyPyllantDataClass):
 
     @classmethod
     def from_api(cls, **data):
-        data["devices"] = [AmbisenseDevice.from_api(**d) for d in data["devices"]]
         data["operation_mode"] = AmbisenseRoomOperationMode(
             data["operation_mode"].upper()
         )

--- a/src/myPyllant/models.py
+++ b/src/myPyllant/models.py
@@ -692,9 +692,9 @@ class AmbisenseDevice(MyPyllantDataClass):
     low_bat: bool
     name: str
     rssi: int
-    rssi_peer: int
     sgtin: str
     unreach: bool
+    rssi_peer: int | None = None
 
 
 @dataclass(config=MyPyllantConfig)

--- a/src/myPyllant/tests/test_models.py
+++ b/src/myPyllant/tests/test_models.py
@@ -12,6 +12,7 @@ from ..models import (
     Device,
     AmbisenseRoom,
     RoomTimeProgram,
+    AmbisenseDevice,
 )
 from ..enums import ZoneHeatingOperatingMode, ControlIdentifier
 from .utils import list_test_data, load_test_data
@@ -156,6 +157,8 @@ async def test_ambisense(mypyllant_aioresponses, mocked_api: MyPyllantAPI) -> No
         assert isinstance(system.ambisense_rooms[0], AmbisenseRoom)
         for room in system.ambisense_rooms:
             assert isinstance(room.name, str)
+            assert isinstance(room.room_configuration.devices[0], AmbisenseDevice)
+            assert len(room.room_configuration.devices[0].name) > 0
             assert isinstance(room.time_program, RoomTimeProgram)
             assert isinstance(room.room_configuration.current_temperature, float)
             if room.room_index == 1:

--- a/src/myPyllant/tests/utils.py
+++ b/src/myPyllant/tests/utils.py
@@ -146,6 +146,20 @@ def _mypyllant_aioresponses():
                 payload={},
                 repeat=True,
             )
+            self.put(
+                re.compile(
+                    r".*/ambisense/.*/rooms/.*/configuration/(operation-mode|quick-veto)$"
+                ),
+                status=200,
+                payload={},
+                repeat=True,
+            )
+            self.delete(
+                re.compile(r".*/ambisense/.*/rooms/.*/configuration/quick-veto$"),
+                status=200,
+                payload={},
+                repeat=True,
+            )
 
             def get_test_data(url: str, key: str, default=None) -> CallbackResult:
                 """


### PR DESCRIPTION
Here it is.

- Creating `AmbisenseRoomOperationMode`, I think it is a good idea to have, like other operation mode enum.
- Creating `AmbisenseDevice`, I don't know if ti is useful, but I think it's cleaner to have it
- Adding `system_id` in `AmbisenseRoom`
- Some tests for new API calls


Still in draft, because I would like to test it a bit more (either real API calls or unit test) and have some feedback from you :)