### PR TITLE
New system sensors: system_flow_temperature and energy_manager_state

### DIFF
--- a/src/myPyllant/enums.py
+++ b/src/myPyllant/enums.py
@@ -134,3 +134,9 @@ class AmbisenseRoomOperationMode(MyPyllantEnum):
     MANUAL = "MANUAL"
     OFF = "OFF"
     AUTO = "AUTO"
+
+
+class EnergyManagerState(MyPyllantEnum):
+    STANDBY = "STANDBY"
+    DHW = "DHW"
+    HEATING = "HEATING"

--- a/src/myPyllant/models.py
+++ b/src/myPyllant/models.py
@@ -1140,6 +1140,16 @@ class System(MyPyllantDataClass):
             return None
 
     @property
+    def system_flow_temperature(self) -> float | None:
+        try:
+            return self.state["system"]["system_flow_temperature"]
+        except KeyError:
+            logger.debug(
+                "Could not get system flow temperature from system control state"
+            )
+            return None
+
+    @property
     def is_cooling_allowed(self) -> bool:
         return any([z.is_cooling_allowed for z in self.zones]) or any(
             [c.is_cooling_allowed for c in self.circuits]

--- a/src/myPyllant/models.py
+++ b/src/myPyllant/models.py
@@ -27,6 +27,7 @@ from myPyllant.enums import (
     AmbisenseRoomOperationMode,
     VentilationOperationModeVRC700,
     ZoneOperatingType,
+    EnergyManagerState,
 )
 from myPyllant.utils import datetime_parse, prepare_field_value_for_dict
 
@@ -1146,6 +1147,17 @@ class System(MyPyllantDataClass):
         except KeyError:
             logger.debug(
                 "Could not get system flow temperature from system control state"
+            )
+            return None
+
+    @property
+    def energy_manager_state(self) -> EnergyManagerState | None:
+        try:
+            return EnergyManagerState(self.state["system"]["energy_manager_state"])
+        except (KeyError, ValueError) as e:
+            logger.debug(
+                "Could not get energy manager state from system control state",
+                exc_info=e,
             )
             return None
 


### PR DESCRIPTION
I am currently investigating an inefficiency in my heating setup and suspect it to be a problem related to the hot water program. 

My setup was built a bit inefficient in my opinion: A heatpump and an electrical heater both heat up a buffer storage. The buffer storage then loads the heater and the hot water at different times: For hot water it heats up, later for regular heating it lets it temperature lower. 

In this setup, the system_flow_temperature is the buffer temperature which is of high interest in my analysis and hence I'd like to have it included. Same goes for energy_manager_state which indicates if the overall system is currently working on heating or producing hot water. 