### PR TITLE
Fix for handling of Zulu time (UTC) when parsing API responses

### DIFF
--- a/src/myPyllant/models.py
+++ b/src/myPyllant/models.py
@@ -67,12 +67,7 @@ class MyPyllantDataClass:
 
         for k, v in data.items():
             if v is not None and k in datetime_fields and timezone is not None:
-                if v.endswith("Z"):
-                    # Some dates are returned as "2024-01-01T00:00:00Z" without timezone information
-                    data[k] = datetime_parse(v, timezone)
-                else:
-                    # ... and some are ISO formatted with timezone information
-                    data[k] = datetime.datetime.fromisoformat(v)
+                data[k] = datetime_parse(v, timezone)
 
         if extra_fields:
             data["extra_fields"] = {f: data[f] for f in extra_fields}

--- a/src/myPyllant/tests/test_utils.py
+++ b/src/myPyllant/tests/test_utils.py
@@ -1,6 +1,24 @@
 from datetime import datetime, timezone
-
 from myPyllant.utils import datetime_parse
+from zoneinfo import ZoneInfo
+
+"""
+Tests for the `datetime_parse` function from the `myPyllant.utils` module.
+
+Functions:
+    test_datetime_parse:
+        Verifies that `datetime_parse` correctly parses ISO 8601 datetime strings
+        with UTC timezone into `datetime` objects.
+
+    test_datetime_parse_local_datetime:
+        Ensures that `datetime_parse` correctly parses ISO 8601 datetime strings
+        with a specified local timezone and returns a `datetime` object with the
+        appropriate timezone information.
+
+    test_datetime_parse_zulu_datetime:
+        Tests that `datetime_parse` correctly handles ISO 8601 datetime strings
+        with a "Z" (Zulu) timezone and converts them to the specified local timezone.
+"""
 
 
 async def test_datetime_parse() -> None:
@@ -8,3 +26,19 @@ async def test_datetime_parse() -> None:
         datetime_parse("2022-03-28T19:37:12.27334Z", timezone.utc), datetime
     )
     assert isinstance(datetime_parse("2022-03-28T19:37:12Z", timezone.utc), datetime)
+
+
+async def test_datetime_parse_local_datetime():
+    london_timezone = ZoneInfo("Europe/London")
+    date_string = "2025-04-10T18:00:03+01:00"
+    parsed_date = datetime_parse(date_string, None)
+    assert isinstance(parsed_date, datetime)
+    assert parsed_date == datetime(2025, 4, 10, 18, 0, 3, tzinfo=london_timezone)
+
+
+async def test_datetime_parse_zulu_datetime():
+    london_timezone = ZoneInfo("Europe/London")
+    date_string = "2025-04-10T17:00:03Z"
+    parsed_date = datetime_parse(date_string, london_timezone)
+    assert isinstance(parsed_date, datetime)
+    assert parsed_date == datetime(2025, 4, 10, 18, 0, 3, tzinfo=london_timezone)


### PR DESCRIPTION
Hi @signalkraft ,

I'd like to propose a small fix I believe is necessary for correct handling of Zulu (UTC) datetime values returned by the Vaillant API.

This is in relation to the issue I raised describing the problem: https://github.com/signalkraft/myPyllant/issues/137.

Pre-commit checks passing in my dev container.

I still need to do further tests in HA, but sharing early for visibility.

Kind regards,
Kamil