### PR TITLE
Add COOLING value to EnergyManagerState enum

### DIFF
--- a/src/myPyllant/enums.py
+++ b/src/myPyllant/enums.py
@@ -146,3 +146,4 @@ class EnergyManagerState(MyPyllantEnum):
     STANDBY = "STANDBY"
     DHW = "DHW"
     HEATING = "HEATING"
+    COOLING = "COOLING"


### PR DESCRIPTION
## Summary

The myVAILLANT API returns `"COOLING"` as `state.system.energy_manager_state` when an aroTHERM heat pump is actively cooling, but `EnergyManagerState` only defines `STANDBY`, `DHW`, and `HEATING`. The unknown value raises `ValueError`, the `System.energy_manager_state` property catches it and returns `None`, and downstream (e.g. the [Home Assistant integration](https://github.com/signalkraft/mypyllant-component)) shows the Energy Manager State sensor as unavailable for the duration of cooling season.

## Reproduction

Observed on an aroTHERM plus (VRC720, control identifier `tli`, system scheme 8) in Portugal during cooling season. Raw API response from `…/systems/<id>/tli`:

```json
"state": {
  "system": {
    "energy_manager_state": "COOLING",
    ...
  },
  "circuits": [
    { "calculated_energy_manager_state": "COOLING_ACTIVE", "circuit_state": "COOLING", ... }
  ]
}
```

Traceback from the HA integration:

```
File "myPyllant/models.py", line 1164, in energy_manager_state
    return EnergyManagerState(self.state["system"]["energy_manager_state"])
ValueError: 'COOLING' is not a valid EnergyManagerState
```

## Change

Add `COOLING = "COOLING"` to `EnergyManagerState`. Mirrors the pattern in `CircuitState`, which already includes `HEATING`, `COOLING`, `STANDBY`.

I only added the value I directly observed. There may be additional values the API can emit (e.g. a combined heating+DHW state) — happy to add more if you have evidence of them.

## Test plan

- [ ] CI on this PR
- [ ] Confirm the Home Assistant `*_energy_manager_state` sensor reports `COOLING` instead of unavailable after a release including this change