### PR TITLE
Fix VRC700 EnergyManagerState missing COOLING and manual_cooling_planned

### DIFF
--- a/src/myPyllant/enums.py
+++ b/src/myPyllant/enums.py
@@ -146,3 +146,4 @@ class EnergyManagerState(MyPyllantEnum):
     STANDBY = "STANDBY"
     DHW = "DHW"
     HEATING = "HEATING"
+    COOLING = "COOLING"

--- a/src/myPyllant/models.py
+++ b/src/myPyllant/models.py
@@ -1280,6 +1280,10 @@ class System(MyPyllantDataClass):
 
     @property
     def manual_cooling_ongoing(self) -> bool:
+        if self.control_identifier.is_vrc700:
+            # VRC700 has no start/end dates, just an on/off flag + remaining days,
+            # so "planned" and "ongoing" are equivalent
+            return self.manual_cooling_planned
         return (
             self.manual_cooling_start_date is not None
             and self.manual_cooling_end_date is not None

--- a/src/myPyllant/models.py
+++ b/src/myPyllant/models.py
@@ -1258,6 +1258,13 @@ class System(MyPyllantDataClass):
 
     @property
     def manual_cooling_planned(self) -> bool:
+        if self.control_identifier.is_vrc700:
+            # VRC700 uses coolingForXDays instead of start/end dates
+            system_config = self.configuration.get("system", {})
+            return (
+                not system_config.get("automatic_cooling_on_off", True)
+                and (system_config.get("cooling_for_x_days") or 0) > 0
+            )
         return (
             self.manual_cooling_start_date is not None
             and self.manual_cooling_end_date is not None

--- a/src/myPyllant/tests/test_api.py
+++ b/src/myPyllant/tests/test_api.py
@@ -339,6 +339,36 @@ async def test_vrc700_operating_mode(
         await mocked_api.aiohttp_session.close()
 
 
+async def test_vrc700_manual_cooling_ongoing(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI
+) -> None:
+    """
+    VRC700 systems don't have manual_cooling_start_date / manual_cooling_end_date,
+    so manual_cooling_ongoing must fall back to manual_cooling_planned (which is
+    based on automatic_cooling_on_off + cooling_for_x_days) instead of always
+    returning False.
+    """
+    test_data = load_test_data(DATA_DIR / "vrc700")
+    with mypyllant_aioresponses(test_data) as _:
+        system = await anext(mocked_api.get_systems())
+        assert system.control_identifier.is_vrc700
+        assert system.manual_cooling_start_date is None
+        assert system.manual_cooling_end_date is None
+
+        system.configuration.setdefault("system", {})["automatic_cooling_on_off"] = (
+            False
+        )
+        system.configuration["system"]["cooling_for_x_days"] = 10
+        assert system.manual_cooling_planned is True
+        assert system.manual_cooling_ongoing is True
+
+        system.configuration["system"]["automatic_cooling_on_off"] = True
+        assert system.manual_cooling_planned is False
+        assert system.manual_cooling_ongoing is False
+
+        await mocked_api.aiohttp_session.close()
+
+
 async def test_vrc700_holiday(mypyllant_aioresponses, mocked_api: MyPyllantAPI) -> None:
     test_data = load_test_data(DATA_DIR / "vrc700")
     with mypyllant_aioresponses(test_data) as aio:


### PR DESCRIPTION
Two VRC700-specific bugs:

1. EnergyManagerState enum was missing COOLING. When the system is in cooling season the API returns energyManagerState: "COOLING", causing EnergyManagerState("COOLING") to raise ValueError. The energy manager state sensor (SystemEnergyManagerStateSensor) was never created as a result, showing as unavailable in Home Assistant.

2. manual_cooling_planned always returned False for VRC700 systems because it checks manual_cooling_start_date/end_date, which are not present in the VRC700 API response. VRC700 uses automaticCoolingOnOff and coolingForXDays instead. Added a VRC700-specific branch that reads these fields directly.

Tested on Vaillant aroTHERM + VRC700 R6 (VR940F) in Spain, summer/cooling mode.