### PR TITLE
Fix DHW temperature setpoint endpoint for VRC700 controllers

### DIFF
--- a/src/myPyllant/api.py
+++ b/src/myPyllant/api.py
@@ -22,6 +22,7 @@ from myPyllant.const import (
     DEFAULT_CONTROL_IDENTIFIER,
     DEFAULT_QUICK_VETO_DURATION,
     LOGIN_URL,
+    SYSTEM_CONTROL_API_URL_BASE,
     TOKEN_URL,
 )
 from myPyllant.enums import (
@@ -1019,15 +1020,22 @@ class MyPyllantAPI:
 
         Parameters:
             domestic_hot_water: The water heater
-            temperature: The desired temperature, only whole numbers are supported by the API, floats get rounded
+            temperature: The desired temperature. VRC700 controllers support 0.5 degree
+                steps, other controllers only support whole numbers and floats get rounded
         """
-        if isinstance(temperature, float):
-            logger.warning("Domestic hot water can only be set to whole numbers")
-            temperature = int(round(temperature, 0))
-        url = (
-            f"{await self.get_system_api_base(domestic_hot_water.system_id)}"
-            f"/domestic-hot-water/{domestic_hot_water.index}/temperature"
-        )
+        if domestic_hot_water.control_identifier.is_vrc700:
+            url = (
+                f"{SYSTEM_CONTROL_API_URL_BASE}/systems/{domestic_hot_water.system_id}"
+                f"/domestic-hot-water/{domestic_hot_water.index}/tapping-setpoint"
+            )
+        else:
+            if isinstance(temperature, float):
+                logger.warning("Domestic hot water can only be set to whole numbers")
+                temperature = int(round(temperature, 0))
+            url = (
+                f"{await self.get_system_api_base(domestic_hot_water.system_id)}"
+                f"/domestic-hot-water/{domestic_hot_water.index}/temperature"
+            )
         await self.aiohttp_session.patch(
             url, json={"setpoint": temperature}, headers=self.get_authorized_headers()
         )

--- a/src/myPyllant/const.py
+++ b/src/myPyllant/const.py
@@ -6,6 +6,9 @@ API_URL_BASE = {
     "tli": "https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1",
     "vrc700": "https://api.vaillant-group.com/service-connected-control/vrc700/v1",
 }
+SYSTEM_CONTROL_API_URL_BASE = (
+    "https://api.vaillant-group.com/service-connected-control/system-control/v1"
+)
 CLIENT_ID = "myvaillant"
 BRANDS = {
     "vaillant": "Vaillant",

--- a/src/myPyllant/tests/utils.py
+++ b/src/myPyllant/tests/utils.py
@@ -89,7 +89,7 @@ def _mypyllant_aioresponses():
             )
             # API endpoints
             actions = re.compile(
-                r".*(away-mode|setBackTemperature|temperature|holiday|cooling-for-days|ventilation-boost)$"
+                r".*(away-mode|setBackTemperature|temperature|tapping-setpoint|holiday|cooling-for-days|ventilation-boost)$"
             )
             self.post(
                 actions,


### PR DESCRIPTION
`set_domestic_hot_water_temperature` now branches on `domestic_hot_water.control_identifier.is_vrc700`:

- VRC700: `PATCH .../system-control/v1/systems/{system_id}/domestic-hot-water/{index}/tapping-setpoint` with `{"setpoint": ...}` (float)
- Non-VRC700: unchanged - `PATCH .../domestic-hot-water/{index}/temperature` with an integer-rounded setpoint

The previous VRC700 code used `.../domestic-hot-water/{index}/temperature`, which doesn't match the endpoint used by the real myVaillant app for VRC700 controllers (captured via mitmproxy).

Adds `SYSTEM_CONTROL_API_URL_BASE` to `const.py` for the new `system-control/v1` API base used by several VRC700 endpoints.

All tests pass (371 passed) and mypy is clean.