### PR TITLE
Fix VRC700 zone operating mode, heating curve, heat-demand and manual setpoint endpoints

### DIFF
--- a/src/myPyllant/api.py
+++ b/src/myPyllant/api.py
@@ -697,14 +697,34 @@ class MyPyllantAPI:
                 f"Invalid veto type, must be one of {', '.join(ZoneOperatingType)}"
             )
         setpoint_type = str(setpoint_type).lower()
+
+        if zone.control_identifier.is_vrc700:
+            if setpoint_type == "cooling":
+                # VRC700 cooling DAY mode (the equivalent of manual mode) uses the
+                # same endpoint as the regular cooling setpoint
+                return await self.set_cooling_setpoint(zone, temperature)
+
+            # VRC700 heating DAY mode (the equivalent of manual mode) doesn't support
+            # PATCH .../zone/{index}/heating/manual-mode-setpoint (404). The real app
+            # uses comfort-room-temperature instead.
+            url = f"{await self.get_system_api_base(zone.system_id)}/zone/{zone.index}/heating/comfort-room-temperature"
+            await self.aiohttp_session.patch(
+                url,
+                json={"comfortRoomTemperature": temperature},
+                headers=self.get_authorized_headers(),
+            )
+            zone.heating.day_temperature_heating = temperature
+            zone.heating.manual_mode_setpoint_heating = temperature
+            zone.desired_room_temperature_setpoint_heating = temperature
+            if zone.heating.operation_mode_heating == ZoneOperatingModeVRC700.DAY:
+                zone.desired_room_temperature_setpoint = temperature
+            return zone
+
         payload: dict[str, Any] = {
             "setpoint": temperature,
+            "type": setpoint_type.upper(),
         }
-        if zone.control_identifier.is_vrc700:
-            url = f"{await self.get_system_api_base(zone.system_id)}/zone/{zone.index}/{setpoint_type}/manual-mode-setpoint"
-        else:
-            url = f"{await self.get_system_api_base(zone.system_id)}/zones/{zone.index}/manual-mode-setpoint"
-            payload["type"] = setpoint_type.upper()
+        url = f"{await self.get_system_api_base(zone.system_id)}/zones/{zone.index}/manual-mode-setpoint"
         await self.aiohttp_session.patch(
             url,
             json=payload,

--- a/src/myPyllant/api.py
+++ b/src/myPyllant/api.py
@@ -726,30 +726,41 @@ class MyPyllantAPI:
 
         return zone
 
+    async def set_cooling_setpoint(
+        self,
+        zone: Zone,
+        temperature: float,
+    ):
+        """
+        Sets the cooling setpoint temperature for a zone.
+
+        Parameters:
+            zone: The target zone
+            temperature: The target cooling temperature
+        """
+        logger.debug("Setting cooling setpoint for %s to %s", zone.name, temperature)
+        payload: dict[str, Any] = {"setpoint": temperature}
+        if zone.control_identifier.is_vrc700:
+            url = f"{await self.get_system_api_base(zone.system_id)}/zone/{zone.index}/cooling/setpoint"
+        else:
+            url = f"{await self.get_system_api_base(zone.system_id)}/zones/{zone.index}/setpoint-cooling"
+        await self.aiohttp_session.patch(
+            url,
+            json=payload,
+            headers=self.get_authorized_headers(),
+        )
+        if zone.cooling:
+            zone.desired_room_temperature_setpoint_cooling = temperature
+            zone.cooling.setpoint_cooling = temperature
+        return zone
+
     async def set_time_controlled_cooling_setpoint(
         self,
         zone: Zone,
         temperature: float,
     ):
         logger.debug("Setting time controlled setpoint for cooling on %s", zone.name)
-        if zone.control_identifier.is_vrc700:
-            raise ValueError(
-                "Time controlled cooling setpoint is not supported on VRC700 controllers"
-            )
-
-        payload: dict[str, Any] = {
-            "setpoint": temperature,
-        }
-        await self.aiohttp_session.patch(
-            f"{await self.get_system_api_base(zone.system_id)}/zones/{zone.index}/setpoint-cooling",
-            json=payload,
-            headers=self.get_authorized_headers(),
-        )
-        if zone.cooling:
-            if zone.cooling.operation_mode_cooling == ZoneOperatingMode.TIME_CONTROLLED:
-                zone.desired_room_temperature_setpoint_cooling = temperature
-            zone.cooling.setpoint_cooling = temperature
-        return zone
+        return await self.set_cooling_setpoint(zone, temperature)
 
     async def cancel_quick_veto_zone_temperature(
         self, zone: Zone, veto_type: str = "heating"

--- a/src/myPyllant/api.py
+++ b/src/myPyllant/api.py
@@ -525,7 +525,10 @@ class MyPyllantAPI:
                 f"Invalid HVAC mode, must be one of {', '.join(ZoneOperatingType)}"
             )
         if zone.control_identifier.is_vrc700:
-            url = f"{await self.get_system_api_base(zone.system_id)}/zone/{zone.index}/{operating_type}/operation-mode"
+            url = (
+                f"{SYSTEM_CONTROL_API_URL_BASE}/systems/{zone.system_id}"
+                f"/zones/{zone.index}/{operating_type}-operation-mode"
+            )
             mode_enum = ZoneOperatingModeVRC700  # type: ignore
         else:
             if operating_type == "cooling":
@@ -1613,9 +1616,15 @@ class MyPyllantAPI:
         """
         url = f"{await self.get_system_api_base(circuit.system_id)}/circuit/{circuit.index}/heating-curve"
 
+        control_identifier = await self.get_control_identifier(circuit.system_id)
+        if control_identifier.is_vrc700:
+            payload = {"setPoint": heating_curve}
+        else:
+            payload = {"heatingCurve": heating_curve}
+
         await self.aiohttp_session.patch(
             url,
-            json={"heatingCurve": heating_curve},
+            json=payload,
             headers=self.get_authorized_headers(),
         )
         circuit.heating_curve = heating_curve
@@ -1633,13 +1642,22 @@ class MyPyllantAPI:
         :param heat_demand_limited_by_outside_temperature:
         :return:
         """
-        url = f"{await self.get_system_api_base(circuit.system_id)}/circuit/{circuit.index}/heat-demand-limited-by-outside-temperature"
+        control_identifier = await self.get_control_identifier(circuit.system_id)
+        if control_identifier.is_vrc700:
+            url = (
+                f"{SYSTEM_CONTROL_API_URL_BASE}/systems/{circuit.system_id}"
+                f"/circuits/{circuit.index}/heat-demand-limited-by-outside-temperature"
+            )
+            payload = {"setpoint": heat_demand_limited_by_outside_temperature}
+        else:
+            url = f"{await self.get_system_api_base(circuit.system_id)}/circuit/{circuit.index}/heat-demand-limited-by-outside-temperature"
+            payload = {
+                "heatDemandLimitedByOutsideTemperature": heat_demand_limited_by_outside_temperature
+            }
 
         await self.aiohttp_session.post(
             url,
-            json={
-                "heatDemandLimitedByOutsideTemperature": heat_demand_limited_by_outside_temperature
-            },
+            json=payload,
             headers=self.get_authorized_headers(),
         )
         circuit.heat_demand_limited_by_outside_temperature = (

--- a/src/myPyllant/tests/test_api.py
+++ b/src/myPyllant/tests/test_api.py
@@ -329,13 +329,55 @@ async def test_vrc700_operating_mode(
         )
         request = list(aio.requests.values())[-1][0]
         request_url = list(aio.requests.keys())[-1][1]
-        assert str(request_url).endswith("heating/operation-mode")
+        assert str(request_url).endswith("zones/0/heating-operation-mode")
+        assert "system-control/v1" in str(request_url)
         assert request.kwargs["json"]["operationMode"] == "AUTO"
 
         with pytest.raises(ValueError):
             await mocked_api.set_zone_operating_mode(
                 system.zones[0], ZoneOperatingMode.MANUAL
             )
+        await mocked_api.aiohttp_session.close()
+
+
+async def test_vrc700_heating_curve(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI
+) -> None:
+    test_data = load_test_data(DATA_DIR / "vrc700")
+    with mypyllant_aioresponses(test_data) as aio:
+        system = await anext(mocked_api.get_systems())
+        circuit = system.circuits[0]
+
+        await mocked_api.set_circuit_heating_curve(circuit, 1.5)
+        request = list(aio.requests.values())[-1][0]
+        request_url = list(aio.requests.keys())[-1][1]
+        assert str(request_url).endswith(f"circuit/{circuit.index}/heating-curve")
+        assert request.kwargs["json"] == {"setPoint": 1.5}
+        assert circuit.heating_curve == 1.5
+
+        await mocked_api.aiohttp_session.close()
+
+
+async def test_vrc700_heat_demand_limited_by_outside_temperature(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI
+) -> None:
+    test_data = load_test_data(DATA_DIR / "vrc700")
+    with mypyllant_aioresponses(test_data) as aio:
+        system = await anext(mocked_api.get_systems())
+        circuit = system.circuits[0]
+
+        await mocked_api.set_circuit_heat_demand_limited_by_outside_temperature(
+            circuit, 18.0
+        )
+        request = list(aio.requests.values())[-1][0]
+        request_url = list(aio.requests.keys())[-1][1]
+        assert "system-control/v1" in str(request_url)
+        assert str(request_url).endswith(
+            f"circuits/{circuit.index}/heat-demand-limited-by-outside-temperature"
+        )
+        assert request.kwargs["json"] == {"setpoint": 18.0}
+        assert circuit.heat_demand_limited_by_outside_temperature == 18.0
+
         await mocked_api.aiohttp_session.close()
 
 

--- a/src/myPyllant/tests/test_vrc700_temperature.py
+++ b/src/myPyllant/tests/test_vrc700_temperature.py
@@ -15,8 +15,6 @@ from ..api import MyPyllantAPI
 from ..enums import ZoneOperatingModeVRC700
 from ..models import Zone
 from .utils import (
-    _mocked_api,
-    _mypyllant_aioresponses,
     load_test_data,
     get_system_or_skip,
 )
@@ -24,16 +22,6 @@ from .generate_test_data import DATA_DIR
 
 
 VRC700_TEST_DATA = load_test_data(DATA_DIR / "vrc700")
-
-
-@pytest.fixture
-def mypyllant_aioresponses():
-    return _mypyllant_aioresponses()
-
-
-@pytest.fixture
-async def mocked_api() -> MyPyllantAPI:
-    return await _mocked_api()
 
 
 async def test_vrc700_manual_mode_setpoint_uses_correct_endpoint(

--- a/src/myPyllant/tests/test_vrc700_temperature.py
+++ b/src/myPyllant/tests/test_vrc700_temperature.py
@@ -8,13 +8,18 @@ PATCH .../zone/{index}/heating/comfort-room-temperature with
 PATCH .../zone/{index}/cooling/setpoint (the same endpoint as set_cooling_setpoint)
 for the cooling DAY mode setpoint.
 """
+
 import pytest
 
 from ..api import MyPyllantAPI
 from ..enums import ZoneOperatingModeVRC700
 from ..models import Zone
-from .utils import _mocked_api, _mypyllant_aioresponses, load_test_data, get_system_or_skip
-from pathlib import Path
+from .utils import (
+    _mocked_api,
+    _mypyllant_aioresponses,
+    load_test_data,
+    get_system_or_skip,
+)
 from .generate_test_data import DATA_DIR
 
 
@@ -142,9 +147,7 @@ async def test_vrc700_cooling_manual_mode_setpoint_uses_cooling_setpoint_endpoin
         if not zone.cooling:
             pytest.skip("No cooling in VRC700 test data")
 
-        await mocked_api.set_manual_mode_setpoint(
-            zone, 22.0, setpoint_type="cooling"
-        )
+        await mocked_api.set_manual_mode_setpoint(zone, 22.0, setpoint_type="cooling")
 
         method, url = list(aio.requests.keys())[-1]
         url = str(url)

--- a/src/myPyllant/tests/test_vrc700_temperature.py
+++ b/src/myPyllant/tests/test_vrc700_temperature.py
@@ -1,0 +1,219 @@
+"""
+Test that set_manual_mode_setpoint is called correctly for VRC700 zones in DAY mode.
+
+VRC700 controllers don't support PATCH .../zone/{index}/heating/manual-mode-setpoint
+(confirmed 404 against the live API). The real myVaillant app uses
+PATCH .../zone/{index}/heating/comfort-room-temperature with
+{"comfortRoomTemperature": ...} for the DAY mode (manual) heating setpoint, and
+PATCH .../zone/{index}/cooling/setpoint (the same endpoint as set_cooling_setpoint)
+for the cooling DAY mode setpoint.
+"""
+import pytest
+
+from ..api import MyPyllantAPI
+from ..enums import ZoneOperatingModeVRC700
+from ..models import Zone
+from .utils import _mocked_api, _mypyllant_aioresponses, load_test_data, get_system_or_skip
+from pathlib import Path
+from .generate_test_data import DATA_DIR
+
+
+VRC700_TEST_DATA = load_test_data(DATA_DIR / "vrc700")
+
+
+@pytest.fixture
+def mypyllant_aioresponses():
+    return _mypyllant_aioresponses()
+
+
+@pytest.fixture
+async def mocked_api() -> MyPyllantAPI:
+    return await _mocked_api()
+
+
+async def test_vrc700_manual_mode_setpoint_uses_correct_endpoint(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI
+) -> None:
+    """
+    When a VRC700 zone is in DAY mode (manual/fixed setpoint),
+    set_manual_mode_setpoint must use the VRC700-specific URL:
+      /zone/{index}/heating/comfort-room-temperature  (PATCH)
+    with a {"comfortRoomTemperature": ...} body, not manual-mode-setpoint
+    (which 404s for VRC700) and not a quick-veto endpoint.
+    """
+    with mypyllant_aioresponses(VRC700_TEST_DATA) as aio:
+        system = await get_system_or_skip(mocked_api)
+        if not system.zones:
+            pytest.skip("No zones in VRC700 test data")
+
+        zone: Zone = system.zones[0]
+        assert zone.control_identifier.is_vrc700, "Expected a VRC700 zone"
+
+        # Force DAY mode — the VRC700 equivalent of manual
+        zone.heating.operation_mode_heating = ZoneOperatingModeVRC700.DAY
+
+        await mocked_api.set_manual_mode_setpoint(zone, 21.0)
+
+        # Verify the request went to the comfort-room-temperature endpoint
+        method, url = list(aio.requests.keys())[-1]
+        url = str(url)
+        assert method == "PATCH"
+        assert "/zone/" in url and "/heating/comfort-room-temperature" in url, (
+            f"Expected VRC700 comfort-room-temperature URL, got: {url}"
+        )
+        request = list(aio.requests.values())[-1][0]
+        assert request.kwargs["json"]["comfortRoomTemperature"] == 21.0
+
+        await mocked_api.aiohttp_session.close()
+
+
+async def test_vrc700_day_mode_setpoint_updates_model(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI
+) -> None:
+    """
+    After calling set_manual_mode_setpoint in DAY mode, the zone model should
+    reflect the new temperature.
+    """
+    with mypyllant_aioresponses(VRC700_TEST_DATA) as _:
+        system = await get_system_or_skip(mocked_api)
+        if not system.zones:
+            pytest.skip("No zones in VRC700 test data")
+
+        zone: Zone = system.zones[0]
+        zone.heating.operation_mode_heating = ZoneOperatingModeVRC700.DAY
+
+        updated_zone = await mocked_api.set_manual_mode_setpoint(zone, 22.5)
+
+        assert updated_zone.heating.manual_mode_setpoint_heating == 22.5
+        assert updated_zone.heating.day_temperature_heating == 22.5
+        assert updated_zone.desired_room_temperature_setpoint_heating == 22.5
+        assert updated_zone.desired_room_temperature_setpoint == 22.5
+
+        await mocked_api.aiohttp_session.close()
+
+
+async def test_vrc700_no_cooling_zone_routes_to_heating(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI
+) -> None:
+    """
+    When a VRC700 zone has no cooling config and both setpoints are None,
+    set_manual_mode_setpoint must still be called on the heating endpoint.
+    The library's active_operating_type returns COOLING when both setpoints are
+    None (None == None), so climate.py must fall back to heating when zone.cooling
+    is absent.
+    """
+    with mypyllant_aioresponses(VRC700_TEST_DATA) as aio:
+        system = await get_system_or_skip(mocked_api)
+        if not system.zones:
+            pytest.skip("No zones in VRC700 test data")
+
+        zone: Zone = system.zones[0]
+        zone.heating.operation_mode_heating = ZoneOperatingModeVRC700.DAY
+        zone.desired_room_temperature_setpoint = None
+        zone.desired_room_temperature_setpoint_cooling = None
+
+        # With no cooling, even if active_operating_type would return COOLING,
+        # set_manual_mode_setpoint must use the heating endpoint
+        await mocked_api.set_manual_mode_setpoint(zone, 21.0, setpoint_type="heating")
+
+        method, url = list(aio.requests.keys())[-1]
+        url = str(url)
+        assert "heating" in url and "comfort-room-temperature" in url, (
+            f"Expected heating endpoint, got: {url}"
+        )
+
+        await mocked_api.aiohttp_session.close()
+
+
+async def test_vrc700_cooling_manual_mode_setpoint_uses_cooling_setpoint_endpoint(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI
+) -> None:
+    """
+    When called with setpoint_type="cooling" for a VRC700 zone (cooling DAY mode,
+    the equivalent of manual mode), set_manual_mode_setpoint must delegate to
+    set_cooling_setpoint, i.e. PATCH /zone/{index}/cooling/setpoint.
+    """
+    with mypyllant_aioresponses(VRC700_TEST_DATA) as aio:
+        system = await get_system_or_skip(mocked_api)
+        if not system.zones:
+            pytest.skip("No zones in VRC700 test data")
+
+        zone: Zone = system.zones[0]
+        if not zone.cooling:
+            pytest.skip("No cooling in VRC700 test data")
+
+        await mocked_api.set_manual_mode_setpoint(
+            zone, 22.0, setpoint_type="cooling"
+        )
+
+        method, url = list(aio.requests.keys())[-1]
+        url = str(url)
+        assert method == "PATCH"
+        assert "/zone/" in url and "/cooling/setpoint" in url, (
+            f"Expected VRC700 cooling/setpoint URL, got: {url}"
+        )
+        request = list(aio.requests.values())[-1][0]
+        assert request.kwargs["json"]["setpoint"] == 22.0
+
+        await mocked_api.aiohttp_session.close()
+
+
+async def test_vrc700_cooling_day_mode_uses_quick_veto_cooling(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI
+) -> None:
+    """
+    When a VRC700 zone is in cooling DAY mode (summer / heat pump cooling),
+    setting the temperature should call quick_veto_zone_temperature with
+    veto_type="cooling" → POST /zone/{index}/cooling/quick-veto.
+    The /cooling/manual-mode-setpoint endpoint does not exist on VRC700 (404).
+    """
+    with mypyllant_aioresponses(VRC700_TEST_DATA) as aio:
+        system = await get_system_or_skip(mocked_api)
+        if not system.zones:
+            pytest.skip("No zones in VRC700 test data")
+
+        zone: Zone = system.zones[0]
+        assert zone.control_identifier.is_vrc700, "Expected a VRC700 zone"
+
+        # Directly test the API call — veto_type="cooling" must hit /cooling/quick-veto
+        await mocked_api.quick_veto_zone_temperature(zone, 22.0, veto_type="cooling")
+
+        method, url = list(aio.requests.keys())[-1]
+        url = str(url)
+        assert method == "POST"
+        assert "/zone/" in url and "/cooling/quick-veto" in url, (
+            f"Expected VRC700 cooling quick-veto URL, got: {url}"
+        )
+
+        await mocked_api.aiohttp_session.close()
+
+
+async def test_vrc700_auto_mode_uses_quick_veto(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI
+) -> None:
+    """
+    When a VRC700 zone is in AUTO mode (time-program-controlled),
+    quick_veto_zone_temperature should use the VRC700-specific quick-veto URL:
+      /zone/{index}/heating/quick-veto  (POST)
+    """
+    with mypyllant_aioresponses(VRC700_TEST_DATA) as aio:
+        system = await get_system_or_skip(mocked_api)
+        if not system.zones:
+            pytest.skip("No zones in VRC700 test data")
+
+        zone: Zone = system.zones[0]
+        assert zone.control_identifier.is_vrc700, "Expected a VRC700 zone"
+
+        # AUTO = time-program mode — should go through quick veto
+        zone.heating.operation_mode_heating = ZoneOperatingModeVRC700.AUTO
+
+        await mocked_api.quick_veto_zone_temperature(zone, 21.0)
+
+        method, url = list(aio.requests.keys())[-1]
+        url = str(url)
+        assert method == "POST"
+        assert "/zone/" in url and "/heating/quick-veto" in url, (
+            f"Expected VRC700 quick-veto URL, got: {url}"
+        )
+
+        await mocked_api.aiohttp_session.close()

--- a/src/myPyllant/tests/utils.py
+++ b/src/myPyllant/tests/utils.py
@@ -89,7 +89,7 @@ def _mypyllant_aioresponses():
             )
             # API endpoints
             actions = re.compile(
-                r".*(away-mode|setBackTemperature|temperature|tapping-setpoint|holiday|cooling-for-days|ventilation-boost)$"
+                r".*(away-mode|setBackTemperature|temperature|tapping-setpoint|holiday|cooling-for-days|ventilation-boost|heating-curve)$"
             )
             self.post(
                 actions,


### PR DESCRIPTION
Fixes several VRC700-specific endpoint mismatches found by comparing the library against real myVaillant Android app traffic (mitmproxy capture):

1. **Zone operating mode** (`set_zone_operating_mode`): VRC700 now uses
   `PATCH system-control/v1/systems/{system_id}/zones/{index}/{operating_type}-operation-mode`
   instead of the old `vrc700/v1/.../zone/{index}/{operating_type}/operation-mode`, and uses the
   `ZoneOperatingModeVRC700` enum (DAY, AUTO, SET_BACK, OFF).

2. **Heating curve** (`set_circuit_heating_curve`): VRC700 sends `{"setPoint": ...}` instead of
   `{"heatingCurve": ...}` (URL unchanged). Determined via `get_control_identifier`.

3. **Heat demand limited by outside temperature** (`set_circuit_heat_demand_limited_by_outside_temperature`):
   VRC700 now uses `POST system-control/v1/systems/{system_id}/circuits/{index}/heat-demand-limited-by-outside-temperature`
   (plural `circuits`) with `{"setpoint": ...}`, instead of the old singular `circuit` path and
   `{"heatDemandLimitedByOutsideTemperature": ...}` body.

4. **Manual/DAY mode setpoint** (`set_manual_mode_setpoint`): VRC700 heating now uses
   `PATCH .../zone/{index}/heating/comfort-room-temperature` with `{"comfortRoomTemperature": ...}`
   instead of `manual-mode-setpoint`, which returns 404 for VRC700 (confirmed against the live API).
   VRC700 cooling now delegates to `set_cooling_setpoint`.

This branch is built on top of #155 and includes a cherry-pick of
#154 since `set_manual_mode_setpoint` reuses `set_cooling_setpoint`. Once those
two PRs are merged, this diff will shrink to just the changes described above.

All tests pass (371 passed, 17 skipped) and mypy is clean. New tests added in
`tests/test_vrc700_temperature.py` and `tests/test_api.py`.