### PR TITLE
Enable ventilation boost + fan-stage on VRC700 controllers

### DIFF
--- a/src/myPyllant/api.py
+++ b/src/myPyllant/api.py
@@ -1023,9 +1023,10 @@ class MyPyllantAPI:
         self,
         system: System,
     ):
-        if system.control_identifier.is_vrc700:
-            raise ValueError("Not supported on VRC700 controllers")
-
+        # The ``ventilation-boost`` endpoint works on VRC700 controllers too — it is
+        # the same system-level endpoint as on TLI/sensoCOMFORT (verified live on a
+        # recoVAIR VAR 260/4 + VRC700: POST -> 202, currentSpecialFunction becomes
+        # VENTILATION_BOOST).
         await self.aiohttp_session.post(
             f"{await self.get_system_api_base(system.id)}/ventilation-boost",
             json={},
@@ -1037,9 +1038,6 @@ class MyPyllantAPI:
         return system
 
     async def cancel_ventilation_boost(self, system: System):
-        if system.control_identifier.is_vrc700:
-            raise ValueError("Not supported on VRC700 controllers")
-
         await self.aiohttp_session.delete(
             f"{await self.get_system_api_base(system.id)}/ventilation-boost",
             headers=self.get_authorized_headers(),
@@ -1232,16 +1230,29 @@ class MyPyllantAPI:
             maximum_fan_stage: The maximum fan speed, from 1-6
             fan_stage_type: The fan stage type (day or night)
         """
-        url = (
-            f"{await self.get_system_api_base(ventilation.system_id)}"
-            f"/ventilation/{ventilation.index}/fan-stage"
-        )
-        await self.aiohttp_session.patch(
-            url,
-            json={
+        json_payload: dict[str, int | str]
+        if ventilation.control_identifier.is_vrc700:
+            # VRC700 exposes separate day/night endpoints and takes only
+            # ``maximumFanStage`` in the body (the ``fan-stage`` endpoint with a
+            # ``type`` field returns 404 there). Verified live on a recoVAIR
+            # VAR 260/4 + VRC700: PATCH .../{day,night}-fan-stage -> 202.
+            url = (
+                f"{await self.get_system_api_base(ventilation.system_id)}"
+                f"/ventilation/{ventilation.index}/{fan_stage_type.lower()}-fan-stage"
+            )
+            json_payload = {"maximumFanStage": maximum_fan_stage}
+        else:
+            url = (
+                f"{await self.get_system_api_base(ventilation.system_id)}"
+                f"/ventilation/{ventilation.index}/fan-stage"
+            )
+            json_payload = {
                 "maximumFanStage": maximum_fan_stage,
                 "type": str(fan_stage_type),
-            },
+            }
+        await self.aiohttp_session.patch(
+            url,
+            json=json_payload,
             headers=self.get_authorized_headers(),
         )
         setattr(

--- a/src/myPyllant/tests/test_vrc700_ventilation.py
+++ b/src/myPyllant/tests/test_vrc700_ventilation.py
@@ -1,0 +1,110 @@
+"""
+VRC700 ventilation boost + fan-stage use the correct endpoints.
+
+Verified live against the Vaillant cloud on a recoVAIR VAR 260/4 + VRC700:
+- boost on/off:  POST/DELETE .../ventilation-boost  (same endpoint as TLI; it is
+                 NOT blocked on VRC700, the previous ValueError was wrong)
+- fan stage:     PATCH .../ventilation/{i}/{day,night}-fan-stage with
+                 {"maximumFanStage": N}  (the /fan-stage endpoint with a ``type``
+                 body returns 404 on VRC700)
+"""
+
+import pytest
+
+from ..api import MyPyllantAPI
+from ..enums import (
+    VentilationFanStageType,
+    VentilationOperationModeVRC700,
+    ZoneCurrentSpecialFunction,
+)
+from ..models import Ventilation
+from .utils import get_system_or_skip, load_test_data
+from .generate_test_data import DATA_DIR
+
+
+VRC700_TEST_DATA = load_test_data(DATA_DIR / "vrc700")
+
+
+def _last_request(aio):
+    method, url = list(aio.requests.keys())[-1]
+    request = list(aio.requests.values())[-1][0]
+    return method, str(url), request
+
+
+def _make_vrc700_ventilation(system) -> Ventilation:
+    # The VRC700 test data has no ventilation device, so build one from the system.
+    return Ventilation(
+        system_id=system.id,
+        index=0,
+        control_identifier=system.control_identifier,
+        maximum_day_fan_stage=6,
+        maximum_night_fan_stage=6,
+        operation_mode_ventilation=VentilationOperationModeVRC700.AUTO,
+        time_program_ventilation={},
+    )
+
+
+async def test_vrc700_set_ventilation_boost_uses_system_endpoint(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI
+) -> None:
+    """set_ventilation_boost must work on VRC700 (no ValueError) and POST to the
+    system-level ventilation-boost endpoint."""
+    with mypyllant_aioresponses(VRC700_TEST_DATA) as aio:
+        system = await get_system_or_skip(mocked_api)
+        assert system.control_identifier.is_vrc700, "Expected a VRC700 system"
+
+        await mocked_api.set_ventilation_boost(system)
+
+        method, url, _ = _last_request(aio)
+        assert method == "POST"
+        assert url.endswith("/ventilation-boost"), url
+        assert system.zones and all(
+            z.current_special_function == ZoneCurrentSpecialFunction.VENTILATION_BOOST
+            for z in system.zones
+        )
+        await mocked_api.aiohttp_session.close()
+
+
+async def test_vrc700_cancel_ventilation_boost(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI
+) -> None:
+    """cancel_ventilation_boost must work on VRC700 and DELETE the same endpoint."""
+    with mypyllant_aioresponses(VRC700_TEST_DATA) as aio:
+        system = await get_system_or_skip(mocked_api)
+
+        await mocked_api.cancel_ventilation_boost(system)
+
+        method, url, _ = _last_request(aio)
+        assert method == "DELETE"
+        assert url.endswith("/ventilation-boost"), url
+        assert system.zones and all(
+            z.current_special_function == ZoneCurrentSpecialFunction.NONE
+            for z in system.zones
+        )
+        await mocked_api.aiohttp_session.close()
+
+
+@pytest.mark.parametrize(
+    "stage_type,segment,attr",
+    [
+        (VentilationFanStageType.DAY, "day-fan-stage", "maximum_day_fan_stage"),
+        (VentilationFanStageType.NIGHT, "night-fan-stage", "maximum_night_fan_stage"),
+    ],
+)
+async def test_vrc700_set_fan_stage_uses_day_night_endpoint(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI, stage_type, segment, attr
+) -> None:
+    """On VRC700, set_ventilation_fan_stage must PATCH the day/night-specific URL
+    with only ``maximumFanStage`` (no ``type`` field)."""
+    with mypyllant_aioresponses(VRC700_TEST_DATA) as aio:
+        system = await get_system_or_skip(mocked_api)
+        ventilation = _make_vrc700_ventilation(system)
+
+        await mocked_api.set_ventilation_fan_stage(ventilation, 3, stage_type)
+
+        method, url, request = _last_request(aio)
+        assert method == "PATCH"
+        assert url.endswith(f"/ventilation/0/{segment}"), url
+        assert request.kwargs["json"] == {"maximumFanStage": 3}
+        assert getattr(ventilation, attr) == 3
+        await mocked_api.aiohttp_session.close()

--- a/src/myPyllant/tests/utils.py
+++ b/src/myPyllant/tests/utils.py
@@ -156,7 +156,9 @@ def _mypyllant_aioresponses():
                 repeat=True,
             )
             self.patch(
-                re.compile(r".*ventilation/.*/(operation-mode|fan-stage)$"),
+                re.compile(
+                    r".*ventilation/.*/(operation-mode|fan-stage|day-fan-stage|night-fan-stage)$"
+                ),
                 status=200,
                 payload={},
                 repeat=True,


### PR DESCRIPTION
## What

Two VRC700 ventilation operations were over-restricted in `api.py`:

1. **Boost** — `set_ventilation_boost` / `cancel_ventilation_boost` raised
   `ValueError("Not supported on VRC700 controllers")`. The system-level
   `POST` / `DELETE .../ventilation-boost` endpoint actually works on VRC700 — it
   is the same endpoint used on TLI/sensoCOMFORT. The guard is removed.

2. **Fan stage** — `set_ventilation_fan_stage` targeted
   `.../ventilation/{i}/fan-stage` with a `{"type": DAY|NIGHT}` body, which returns
   404 on VRC700. VRC700 exposes separate `.../ventilation/{i}/{day,night}-fan-stage`
   endpoints that take only `{"maximumFanStage": N}`.

## Verified live

Against the Vaillant cloud on a **recoVAIR VAR 260/4 + sensoCOMFORT/VRC700**
(authenticated raw requests, self-restoring tests):

| Operation | Request | Result |
|---|---|---|
| boost on | `POST .../vrc700/v1/systems/<id>/ventilation-boost` `{}` | 202 → `currentSpecialFunction = VENTILATION_BOOST` |
| boost off | `DELETE .../ventilation-boost` | 202 → `NONE` |
| fan stage day | `PATCH .../ventilation/0/day-fan-stage` `{"maximumFanStage": N}` | 202 |
| fan stage night | `PATCH .../ventilation/0/night-fan-stage` `{"maximumFanStage": N}` | 202 |
| (old) fan-stage + type | `PATCH .../ventilation/0/fan-stage` `{..., "type": "DAY"}` | 404 |

## Tests

- New `tests/test_vrc700_ventilation.py` — boost on/off and day/night fan stage on VRC700.
- The test fixture (`tests/utils.py`) now also mocks the `{day,night}-fan-stage` endpoints.
- Full suite: **376 passed, 17 skipped**; `ruff` and `mypy` clean.

## Related

Addresses the recoVAIR boost/fan-stage gap reported in the component repo:
signalkraft/mypyllant-component#210, #220, #301, #303 (boost) and #129 (fan stage).
The matching component-side operation-mode fix is in
signalkraft/mypyllant-component#456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_016HSmsSf6z6gnknM9zu8Gry
