### PR TITLE
Add `scf` control identifier (iQconnect / VR_NEEXT)

### DIFF
--- a/src/myPyllant/const.py
+++ b/src/myPyllant/const.py
@@ -5,6 +5,7 @@ TOKEN_URL = AUTH_BASE_URL + "/{realm}/protocol/openid-connect/token"
 API_URL_BASE = {
     "tli": "https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1",
     "vrc700": "https://api.vaillant-group.com/service-connected-control/vrc700/v1",
+    "scf": "https://api.vaillant-group.com/service-connected-control/scf/v1",
 }
 SYSTEM_CONTROL_API_URL_BASE = (
     "https://api.vaillant-group.com/service-connected-control/system-control/v1"

--- a/src/myPyllant/enums.py
+++ b/src/myPyllant/enums.py
@@ -28,11 +28,16 @@ class MyPyllantEnum(str, Enum, metaclass=MyPyllantEnumMeta):
 class ControlIdentifier(MyPyllantEnum):
     TLI = "tli"
     VRC700 = "vrc700"
+    SCF = "scf"
     UNSUPPORTED = "unsupported"
 
     @property
     def is_vrc700(self) -> bool:
         return self == ControlIdentifier.VRC700
+
+    @property
+    def is_scf(self) -> bool:
+        return self == ControlIdentifier.SCF
 
     @property
     def is_unsupported(self) -> bool:

--- a/src/myPyllant/tests/test_scf.py
+++ b/src/myPyllant/tests/test_scf.py
@@ -1,0 +1,42 @@
+"""
+Tests for the ``scf`` control identifier (Vaillant iQconnect generation, e.g. VR_NEEXT).
+
+iQconnect systems report ``controlIdentifier == "scf"`` from
+``/systems/{id}/meta-info/control-identifier``. Before ``scf`` was a member of the
+``ControlIdentifier`` enum, ``ControlIdentifier("scf")`` raised ``ValueError`` in
+``get_control_identifier()`` and aborted the whole data fetch. These tests lock in that
+``scf`` resolves and that the URL helpers treat it like the generic (non-tli) base.
+"""
+
+from ..api import get_api_base, get_system_api_base
+from ..const import API_URL_BASE
+from ..enums import ControlIdentifier
+
+
+def test_scf_is_a_valid_control_identifier() -> None:
+    assert ControlIdentifier("scf") is ControlIdentifier.SCF
+    assert ControlIdentifier.SCF.value == "scf"
+
+
+def test_is_scf_property() -> None:
+    assert ControlIdentifier.SCF.is_scf
+    assert not ControlIdentifier.TLI.is_scf
+    assert not ControlIdentifier.VRC700.is_scf
+    # scf is its own identifier, not a flavour of the others
+    assert not ControlIdentifier.SCF.is_vrc700
+    assert not ControlIdentifier.SCF.is_unsupported
+
+
+def test_scf_has_a_base_url() -> None:
+    assert "scf" in API_URL_BASE
+    assert get_api_base(ControlIdentifier.SCF) == API_URL_BASE["scf"]
+    assert get_api_base("scf") == API_URL_BASE["scf"]
+
+
+def test_scf_system_api_base_uses_generic_shape() -> None:
+    # scf falls into the generic ``case _`` branch (like vrc700): plain /systems/{id},
+    # no /tli suffix.
+    system_id = "00000000-0000-0000-0000-000000000000"
+    assert get_system_api_base(system_id, ControlIdentifier.SCF) == (
+        f"{API_URL_BASE['scf']}/systems/{system_id}"
+    )


### PR DESCRIPTION
## What
Adds the `scf` control identifier to `ControlIdentifier` (with an `is_scf` property) and a
`scf` entry to `API_URL_BASE`.

## Why
iQconnect-generation Vaillant systems (system controller + internet module built into the
appliance, product type `VR_NEEXT`, e.g. geoCOMPACT VWS 52/8.1 iQ) report
`controlIdentifier == "scf"` from `/systems/{id}/meta-info/control-identifier`. Because `scf`
was not a member of the enum, `ControlIdentifier("scf")` raised `ValueError` in
`get_control_identifier()` and aborted the whole data fetch (0 systems). Same failure class as
the unexpected-identifier crashes tracked in mypyllant-component #467 / #207.

## Changes
- `enums.py`: `SCF = "scf"` + `is_scf` property (mirrors `is_vrc700`).
- `const.py`: `API_URL_BASE["scf"]` so the URL helpers treat scf like the generic (non-tli) base.
- `tests/test_scf.py`: enum resolution, `is_scf`, base URL + `get_system_api_base` shape.

## Testing
`pytest tests/test_scf.py` → 4 passed. `ruff format --check`, `ruff check`, `mypy`, and
`codespell` clean on the changed files.

## Follow-up
The Home Assistant component side (new scf entities + `scf_set_schedule` service) is a separate
PR against `signalkraft/mypyllant-component`; it bumps its `myPyllant==` pin once this is
released. The scf entity code has been validated live on a real device (94 entities, 5 controls,
3 editable weekly schedules; write paths confirmed via idempotent no-op probes).

---
*AI disclosure (per AGENTS.md): this PR was prepared with AI assistance. The API behaviour was
reverse-engineered and verified against real iQconnect hardware; all code and tests were
human-reviewed before submission.*
