### PR TITLE
Add scf test data + skip scf systems in get_systems

### DIFF
--- a/src/myPyllant/api.py
+++ b/src/myPyllant/api.py
@@ -356,7 +356,9 @@ class MyPyllantAPI:
         no_facility_error: AmbisenseNoFacilityError | None = None
         for home in homes:
             control_identifier = await self.get_control_identifier(home.system_id)
-            if control_identifier.is_unsupported:
+            # scf/iQconnect systems have no aggregate System (their state comes from
+            # system-control/v1 and is handled by the consumer); skip them here.
+            if control_identifier.is_unsupported or control_identifier.is_scf:
                 continue
             system_url = await self.get_system_api_base(home.system_id)
             assert (

--- a/src/myPyllant/tests/data/scf/a1b2c3d4e5f60718293a4b5c6d7e8f9012345678/connection_status.json
+++ b/src/myPyllant/tests/data/scf/a1b2c3d4e5f60718293a4b5c6d7e8f9012345678/connection_status.json
@@ -1,0 +1,3 @@
+{
+  "connected": true
+}

--- a/src/myPyllant/tests/data/scf/a1b2c3d4e5f60718293a4b5c6d7e8f9012345678/control_identifier.json
+++ b/src/myPyllant/tests/data/scf/a1b2c3d4e5f60718293a4b5c6d7e8f9012345678/control_identifier.json
@@ -1,0 +1,3 @@
+{
+  "controlIdentifier": "scf"
+}

--- a/src/myPyllant/tests/data/scf/a1b2c3d4e5f60718293a4b5c6d7e8f9012345678/time_zone.json
+++ b/src/myPyllant/tests/data/scf/a1b2c3d4e5f60718293a4b5c6d7e8f9012345678/time_zone.json
@@ -1,0 +1,3 @@
+{
+  "timeZone": "Europe/Berlin"
+}

--- a/src/myPyllant/tests/data/scf/homes.json
+++ b/src/myPyllant/tests/data/scf/homes.json
@@ -1,0 +1,20 @@
+[
+  {
+    "homeName": "Home",
+    "serialNumber": "0f1e2d3c4b5a69788796a5b4c3d2e1f001234567",
+    "systemId": "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+    "productMetadata": {
+      "productType": "VR_NEEXT",
+      "productionYear": "24",
+      "productionWeek": "10",
+      "articleNumber": "0010047641"
+    },
+    "state": "CLAIMED",
+    "migrationState": "FINISHED",
+    "firmwareVersion": "0000.00.00",
+    "nomenclature": "iQconnect",
+    "cag": false,
+    "countryCode": "DE",
+    "productInformation": "VR_NEEXT"
+  }
+]

--- a/src/myPyllant/tests/test_scf.py
+++ b/src/myPyllant/tests/test_scf.py
@@ -8,9 +8,11 @@ iQconnect systems report ``controlIdentifier == "scf"`` from
 ``scf`` resolves and that the URL helpers treat it like the generic (non-tli) base.
 """
 
-from ..api import get_api_base, get_system_api_base
+from ..api import MyPyllantAPI, get_api_base, get_system_api_base
 from ..const import API_URL_BASE
 from ..enums import ControlIdentifier
+from .generate_test_data import DATA_DIR
+from .utils import load_test_data
 
 
 def test_scf_is_a_valid_control_identifier() -> None:
@@ -40,3 +42,16 @@ def test_scf_system_api_base_uses_generic_shape() -> None:
     assert get_system_api_base(system_id, ControlIdentifier.SCF) == (
         f"{API_URL_BASE['scf']}/systems/{system_id}"
     )
+
+
+async def test_scf_home_is_skipped_by_get_systems(
+    mypyllant_aioresponses, mocked_api: MyPyllantAPI
+) -> None:
+    """An scf/iQconnect home has no aggregate System, so get_systems skips it (like an
+    unsupported controller). Its state is served by system-control/v1 and handled by the
+    consumer (the Home Assistant component), not by the System model here."""
+    test_data = load_test_data(DATA_DIR / "scf")
+    with mypyllant_aioresponses(test_data) as _:
+        systems = [s async for s in mocked_api.get_systems()]
+        await mocked_api.aiohttp_session.close()
+    assert systems == []

--- a/src/myPyllant/tests/utils.py
+++ b/src/myPyllant/tests/utils.py
@@ -321,10 +321,11 @@ async def _mocked_api(*args, **kwargs) -> MyPyllantAPI:
 def _yields_systems(test_data) -> bool:
     """Return True if the fixture produces at least one System.
 
-    Mirrors api.get_systems: a home whose control identifier is UNSUPPORTED is
-    skipped by the API, so such homes never yield a System object.  A fixture
-    yields systems iff at least one home has a non-unsupported control identifier
-    (or the identifier is missing/unknown, in which we assume a supported system).
+    Mirrors api.get_systems: a home whose control identifier is UNSUPPORTED or SCF is
+    skipped by the API (scf/iQconnect systems have no aggregate System), so such homes
+    never yield a System object.  A fixture yields systems iff at least one home has a
+    control identifier that is neither unsupported nor scf (or the identifier is
+    missing/unknown, in which case we assume a supported system).
     """
     from myPyllant.enums import ControlIdentifier
 
@@ -335,10 +336,8 @@ def _yields_systems(test_data) -> bool:
             .get("controlIdentifier")
         )
         try:
-            if (
-                control_identifier is None
-                or not ControlIdentifier(control_identifier).is_unsupported
-            ):
+            ci = ControlIdentifier(control_identifier) if control_identifier else None
+            if ci is None or not (ci.is_unsupported or ci.is_scf):
                 return True
         except ValueError:
             # Unknown identifier — assume supported


### PR DESCRIPTION
Follow-up to #160 (merged), addressing the request for test data.

scf/iQconnect systems have no aggregate `System` endpoint — `/{controlIdentifier}/v1/systems/{id}` returns 404 for them; their state comes from `system-control/v1/systems/{id}/state` and is consumed on the Home Assistant component side, not by the `System` model here.

## Changes
- `api.py`: `get_systems()` now skips scf homes the same way it skips `unsupported` (they yield no aggregate `System`).
- `tests/data/scf/`: an anonymized scenario (`homes.json` with `VR_NEEXT`/`iQconnect`, `control_identifier.json` = `scf`, plus `connection_status`/`time_zone`), modelled on `unsupported_control_identifier`. No real device identifiers.
- `tests/utils.py`: `_yields_systems` mirrors the skip so the `only_with_systems` filter classifies scf fixtures correctly.
- `tests/test_scf.py`: asserts a scf home yields no `System`.

## Testing
Full suite: **401 passed, 31 skipped**. `ruff format --check`, `ruff check`, `mypy`, and `codespell` clean.

*(AI-assisted; API reverse-engineered and verified on real hardware, human-reviewed.)*
