### PR TITLE
Solve ALTCHA proof-of-work challenge during login

### DIFF
--- a/src/myPyllant/api.py
+++ b/src/myPyllant/api.py
@@ -14,6 +14,7 @@ from zoneinfo import ZoneInfo
 from aiohttp import ClientResponseError
 
 from myPyllant.const import (
+    ALTCHA_CHALLENGE_URL,
     API_URL_BASE,
     AUTHENTICATE_URL,
     BRANDS,
@@ -69,6 +70,7 @@ from myPyllant.utils import (
     generate_code,
     get_realm,
     get_default_holiday_dates,
+    solve_altcha_challenge,
 )
 
 logger = logging.getLogger(__name__)
@@ -206,6 +208,16 @@ class MyPyllantAPI:
                 "password": self.password,
                 "credentialId": "",
             }
+            try:
+                async with self.aiohttp_session.get(ALTCHA_CHALLENGE_URL) as resp:
+                    if resp.status == 200:
+                        challenge = await resp.json()
+                        login_payload["altcha"] = solve_altcha_challenge(challenge)
+            except Exception:
+                logger.debug(
+                    "Could not fetch or solve ALTCHA challenge, continuing without it",
+                    exc_info=True,
+                )
             # Obtaining the code
             async with self.aiohttp_session.post(
                 login_url, data=login_payload, allow_redirects=False

--- a/src/myPyllant/const.py
+++ b/src/myPyllant/const.py
@@ -2,6 +2,7 @@ AUTH_BASE_URL = "https://identity.vaillant-group.com/auth/realms"
 LOGIN_URL = AUTH_BASE_URL + "/{realm}/login-actions/authenticate"
 AUTHENTICATE_URL = AUTH_BASE_URL + "/{realm}/protocol/openid-connect/auth"
 TOKEN_URL = AUTH_BASE_URL + "/{realm}/protocol/openid-connect/token"
+ALTCHA_CHALLENGE_URL = "https://identity.vaillant-group.com/api/altcha/challenge"
 API_URL_BASE = {
     "tli": "https://api.vaillant-group.com/service-connected-control/end-user-app-api/v1",
     "vrc700": "https://api.vaillant-group.com/service-connected-control/vrc700/v1",

--- a/src/myPyllant/tests/test_utils.py
+++ b/src/myPyllant/tests/test_utils.py
@@ -1,5 +1,8 @@
+import base64
+import hashlib
+import json
 from datetime import datetime, timezone
-from myPyllant.utils import datetime_parse
+from myPyllant.utils import datetime_parse, solve_altcha_challenge
 from zoneinfo import ZoneInfo
 
 """
@@ -42,3 +45,43 @@ async def test_datetime_parse_zulu_datetime():
     parsed_date = datetime_parse(date_string, london_timezone)
     assert isinstance(parsed_date, datetime)
     assert parsed_date == datetime(2025, 4, 10, 18, 0, 3, tzinfo=london_timezone)
+
+
+def test_solve_altcha_challenge():
+    """
+    Uses a low `cost` and a one-byte `keyPrefix` so the proof-of-work solves
+    almost instantly, then checks the returned payload against the same
+    PBKDF2 derivation the Vaillant login server verifies it with.
+    """
+    challenge = {
+        "parameters": {
+            "algorithm": "PBKDF2/SHA-256",
+            "cost": 10,
+            "keyLength": 32,
+            "keyPrefix": "00",
+            "nonce": "19398d35354f4059a03226019c7b9915",
+            "salt": "df78709ec7a451e5eacc099b09e2e9a7",
+        },
+        "signature": "some-server-signature",
+    }
+
+    payload = solve_altcha_challenge(challenge)
+    decoded = json.loads(base64.b64decode(payload))
+
+    assert decoded["challenge"]["parameters"] == challenge["parameters"]
+    assert decoded["challenge"]["signature"] == challenge["signature"]
+
+    solution = decoded["solution"]
+    parameters = challenge["parameters"]
+    password = bytes.fromhex(parameters["nonce"]) + solution["counter"].to_bytes(
+        4, byteorder="big"
+    )
+    expected_key = hashlib.pbkdf2_hmac(
+        "sha256",
+        password,
+        bytes.fromhex(parameters["salt"]),
+        parameters["cost"],
+        dklen=parameters["keyLength"],
+    )
+    assert solution["derivedKey"] == expected_key.hex()
+    assert expected_key.startswith(bytes.fromhex(parameters["keyPrefix"]))

--- a/src/myPyllant/utils.py
+++ b/src/myPyllant/utils.py
@@ -1,6 +1,7 @@
 import argparse
 import base64
 import hashlib
+import json
 import random
 import re
 import string
@@ -8,6 +9,51 @@ from datetime import datetime, tzinfo, timezone, timedelta
 from enum import Enum
 
 from myPyllant.const import BRANDS, COUNTRIES, DEFAULT_BRAND, DEFAULT_HOLIDAY_DURATION
+
+
+def solve_altcha_challenge(challenge: dict) -> str:
+    """
+    Solves the ALTCHA proof-of-work challenge served by Vaillant's Keycloak login
+    page (identity.vaillant-group.com), then packages the solution the same way
+    the browser widget does, so it can be sent as the "altcha" login form field.
+
+    `challenge` is the JSON body returned by GET /api/altcha/challenge, e.g.
+    {"parameters": {"algorithm": "PBKDF2/SHA-256", "cost": 5000,
+    "keyLength": 32, "keyPrefix": "00", "nonce": "...", "salt": "..."},
+    "signature": "..."}
+    """
+    parameters = challenge["parameters"]
+    nonce_buf = bytes.fromhex(parameters["nonce"])
+    salt_buf = bytes.fromhex(parameters["salt"])
+    key_prefix_buf = bytes.fromhex(parameters["keyPrefix"])
+    cost = parameters["cost"]
+    key_length = parameters.get("keyLength", 32)
+    digest = {
+        "PBKDF2/SHA-512": "sha512",
+        "PBKDF2/SHA-384": "sha384",
+    }.get(parameters["algorithm"], "sha256")
+
+    counter = 0
+    while True:
+        password = nonce_buf + counter.to_bytes(4, byteorder="big")
+        derived = hashlib.pbkdf2_hmac(
+            digest, password, salt_buf, cost, dklen=key_length
+        )
+        if derived.startswith(key_prefix_buf):
+            solution = {"counter": counter, "derivedKey": derived.hex(), "time": 0}
+            break
+        counter += 1
+
+    payload = {
+        "challenge": {
+            "parameters": parameters,
+            "signature": challenge["signature"],
+        },
+        "solution": solution,
+    }
+    return base64.b64encode(
+        json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    ).decode("utf-8")
 
 
 def dict_to_snake_case(d):


### PR DESCRIPTION
## Problem

Vaillant's Keycloak login page (`identity.vaillant-group.com`) now serves an **ALTCHA** proof-of-work widget on the login form:

```html
<altcha-widget challenge="/api/altcha/challenge" name="altcha" type="checkbox" auto="off" ...>
</altcha-widget>
```

`MyPyllantAPI.get_code()` POSTs `username`/`password`/`credentialId` straight to the rendered form, same as it's always done, but never solves the ALTCHA challenge. Keycloak now rejects that with:

```
Altcha-verificatie mislukt. Probeer het opnieuw.
```

("Altcha verification failed. Try again.") — regardless of whether the credentials are correct. This is why the same password works fine in the myVAILLANT app but always fails through the integration, and matches [signalkraft/mypyllant-component#471](https://github.com/signalkraft/mypyllant-component/issues/471) and the several other reports on that issue. It's not a regression from a recent release either — I rolled the component back to v0.9.16 (`myPyllant==0.9.15`) and it fails identically, since the login flow hasn't materially changed across recent versions. This is a server-side change on Vaillant's end.

## Fix

`GET https://identity.vaillant-group.com/api/altcha/challenge` returns:

```json
{"parameters": {"algorithm": "PBKDF2/SHA-256", "cost": 5000, "keyLength": 32, "keyPrefix": "00", "nonce": "...", "salt": "..."}, "signature": "..."}
```

I pulled the actual widget bundle straight from the login page's own JS to get the real solving algorithm rather than guessing: PBKDF2-HMAC over `nonce || big_endian_uint32(counter)` with `salt`/`cost`/`keyLength` from the challenge, incrementing `counter` until the derived key's byte-prefix matches `keyPrefix`. The result is wrapped as `{"challenge": {"parameters": ..., "signature": ...}, "solution": {"counter": ..., "derivedKey": ..., "time": ...}}`, base64-encoded, and sent as the `altcha` form field alongside the existing login fields — exactly what the browser widget does.

This adds `solve_altcha_challenge()` in `utils.py` and calls it from `get_code()` in `api.py`, wrapped in try/except so login still falls back to the current behavior if a realm doesn't serve a challenge (e.g. if Vaillant rolls this back, or a future country/brand realm doesn't have it enabled).

## Testing

- Solved a live challenge and completed a real login end-to-end: fetch challenge → solve → POST login → got back a `302` with a valid `code=...` in the `Location` header.
- Reloaded the full Home Assistant `mypyllant` integration against a real account afterward — it authenticates and pulls live sensor data (firmware version, heating mode, online status, etc.) with no errors.
- Added `test_solve_altcha_challenge` in `test_utils.py`, which checks the returned payload against an independently recomputed PBKDF2 derivation.
- `uv run prek --skip pytest` (ruff check, ruff format, codespell, mypy) and `uv run pytest` (397 passed, 18 skipped) both pass.


Closes the authentication failure reported in signalkraft/mypyllant-component#471.
